### PR TITLE
Fixed python-style (colons) if-blocks in tabtool.rb.

### DIFF
--- a/flattery/tabtool.rb
+++ b/flattery/tabtool.rb
@@ -235,7 +235,7 @@ module Flattery
         def onLButtonDown(flags, x, y, view)
             update_flags(flags, view)
             
-            if @active_edge:
+            if @active_edge
                 if @dragging
                     ray = view.pickray(x,y)
                     width, inset = width_and_inset(ray)
@@ -273,7 +273,7 @@ module Flattery
         
         def onLButtonUp(flags, x, y, view)
             update_flags(flags, view)
-            if @active_edge && @dragging:
+            if @active_edge && @dragging
                 ray = view.pickray(x,y)
                 width, inset = width_and_inset(ray)
                     
@@ -284,7 +284,7 @@ module Flattery
         
         def onLButtonDoubleClick(flags, x, y, view)
             update_flags(flags, view)
-            if @active_edge:
+            if @active_edge
                 auto_tab(@active_edge)
                 reset(view)
             end


### PR DESCRIPTION
SU 14 (OS X 10.9.4, ruby 2.0.0p451) threw errors on open.
